### PR TITLE
Inaki: refactored store class a bit to use object spread, leaner return notation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ gulp.task('build:es6', () => {
             debug: true
         })
         .transform('babelify', {
-            presets: ['es2015', 'react'],
+            presets: ['es2015', 'react', 'stage-2'],
             plugins: ['transform-class-properties']
         })
         .bundle()

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",
+    "babel-preset-stage-2": "^6.22.0",
     "babelify": "^7.3.0",
     "browserify": "^14.1.0",
     "gulp": "^3.9.1",

--- a/src/state/store.es6
+++ b/src/state/store.es6
@@ -1,6 +1,5 @@
 import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
-
 import { arrayToObject } from './../utils.es6'
 
 const SET_TOGGLES = 'SET_TOGGLES'
@@ -18,56 +17,46 @@ const defaultState = {
   apiKey: localStorage.getItem(API_KEY)
 }
 
-const addToggleToState = (state, toggle) => {
-  const toggleObj = {}
-  toggleObj[toggle.id] = toggle
-
-  return Object.assign({}, state, {toggles: Object.assign({}, state.toggles, toggleObj)})
+const addToggleToState = (state, toggle) => {  
+  const toggles = {...state.toggles, [toggle.id] : toggle}
+  return {...state, toggles}
 }
 
 const removeToggleFromState = (state, toggleId) => {
-  const toggles = Object.assign({}, state.toggles)
-  delete toggles[toggleId]
-
-  return Object.assign({}, state, {toggles})
+  const {
+    toggleId: ignore, // eslint-disable-line no-unused-vars
+    ...toggles
+  } = state.toggles
+  
+  return {...state, toggles}
 }
 
 const reducer = (state = defaultState, action) => {
   switch(action.type) {
     case SET_TOGGLES:
-      return Object.assign({}, state, {toggles: arrayToObject(action.toggles, "id")})
+      return {...state, toggles: arrayToObject(action.toggles, "id")}
     case SET_TOGGLE:
       return addToggleToState(state, action.toggle)
     case DROP_TOGGLE:
       return removeToggleFromState(state, action.toggleId)
     case SET_API_KEY:
       localStorage.setItem(API_KEY, action.apiKey)
-      return Object.assign({}, state, {apiKey: action.apiKey})
+      return {...state, apiKey: action.apiKey}
     case SET_AUDIT_LOG:
-      return Object.assign({}, state, {auditLog: action.auditLog})
+      return {...state, auditLog: action.auditLog}
     default:
       return state
   }
 }
 
-export const setAuditLog = auditLog => {
-  return {type: SET_AUDIT_LOG, auditLog}
-}
+export const setAuditLog = auditLog => ({ type: SET_AUDIT_LOG, auditLog })
 
-export const setApiKey = apiKey => {
-  return {type: SET_API_KEY, apiKey}
-}
+export const setApiKey = apiKey => ({ type: SET_API_KEY, apiKey })
 
-export const setToggles = toggles => {
-  return {type: SET_TOGGLES, toggles}
-}
+export const setToggles = toggles => ({ type: SET_TOGGLES, toggles })
 
-export const setToggle = toggle => {
-  return {type: SET_TOGGLE, toggle}
-}
+export const setToggle = toggle => ({ type: SET_TOGGLE, toggle })
 
-export const dropToggle = toggleId => {
-  return {type: DROP_TOGGLE, toggleId}
-}
+export const dropToggle = toggleId => ({ type: DROP_TOGGLE, toggleId })
 
 export const store = createStore(reducer, applyMiddleware(thunk))


### PR DESCRIPTION
@ArchDev Compiles and runs but haven't tested it at runtime level to see if states change as they should, I can't get a connection locally to the backend. But I think it shows how nicely how to use object spread to reduce boilerplate.

I'll fix the merge conflict later