### PR TITLE
Include greater audience in warning text

### DIFF
--- a/src/auditLogPage.es6
+++ b/src/auditLogPage.es6
@@ -107,7 +107,7 @@ export const AuditLogPage =
                               <ul className="search-panel">
                                 <li>
                                   <h4 className="title">History log</h4>
-                                  <a className="black">We know everything about you, dude</a>
+                                  <a className="black">We know everything about you, folks</a>
                                 </li>
                                 <li className="with-margin">
                                   <div className="form-group">


### PR DESCRIPTION
This PR replaces the term "dude" with a more gender-neutral alternative in order to address a greater audience with the warning text.

The [Oxford dictionary](https://en.oxforddictionaries.com/definition/dude) defines dude as "A man; a guy (often as a form of address)". According to [Wikipedia](https://en.wikipedia.org/wiki/Dude), the address is "typically male". 

But instead of hitting y'all with a dictionary, I'd just ask the following: Are there people who might not feel they're being meant when you call them "dude"? If yes, they might miss the communication.

Also: [There is only one dude](https://www.imdb.com/title/tt0118715/quotes).