### PR TITLE
Gulpfile changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,23 @@ Webpanel for managing [Toguru](https://github.com/AutoScout24/toguru) toggles.
 Download last version (1.1.7) of toguru-panel [here](https://github.com/AutoScout24/toguru-panel/releases/download/1.1.7/toguru-panel.zip), configure it and run! 
 
 ### Configuration
-In `config.json` file you can configure toguru-panel for your own purposes.
+In `baseConfig.json` file you can configure toguru-panel for your own purposes.
 - `apiUrl` - link to your Toguru service instance
 - `slackLink` (optional) - Link on your Slack channel for support. To find out team id please use this [team.info API](https://api.slack.com/methods/team.info) and for channel id use this [channels.list API](https://api.slack.com/methods/channels.list)
 - `hashRouting` (optional, true/false) - enable hash routing for cases when toguru-panel must be served from filesystem
 - `entriesPerPage` (optional) - configure how much entries must be per one page of list.
 
 ### Build
-If you want to build your distributive of toguru-panel manually, you might have preinstalled [NodeJS](https://nodejs.org/) and [Gulp](http://gulpjs.com/).  
-To run production build, use: `gulp dist:production`.
+If you want to build your distributive of toguru-panel manually, you might have preinstalled [NodeJS](https://nodejs.org/), [Yarn](https://yarnpkg.com/) and [Gulp](http://gulpjs.com/).  
+To run production build, use: `yarn gulp dist:production`.
 
 ### Development
-If you want to develop toguru-panel, use default gulp task. It will serve application with watches and fast development builds.
+If you want to develop toguru-panel, use `yarn dev`.
+It will serve application with watches and fast development builds.
+During development [Toguru](https://github.com/Scout24/toguru) needs to be running locally since the default apiUrl is `localhost:9000`.
 
-To override default api url for development, please use --apiUrl parameter.  
-`gulp --apiUrl https://toguru.autoscout24.com`.
+To override the default api url for development, please use --apiUrl parameter.  
+`yarn dev --apiUrl https://toguru.autoscout24.com`.
 
 ### Docker
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,10 +30,16 @@ gulp.task('copy:statics', () => {
 })
 
 gulp.task('build:config', () => {
-  const defaultApiUrl = 'https://toguru.autoscout24.com'
-  gulp.src('./dist/config.json')
-      .pipe(replace(defaultApiUrl, argv.apiUrl || defaultApiUrl))
-      .pipe(gulp.dest('./dist'))
+    const enviroment = gutil.env.env
+    console.log(`Enviroment => ${enviroment}`)
+    let config = require('./src/conf/baseConfig.json')
+    if( enviroment === "dev"){
+        const devConfig = require('./src/conf/devConfig.json')
+        config = Object.assign({}, config, devConfig)
+    }
+    
+    return newFile("config.json", JSON.stringify(config))
+                .pipe(gulp.dest("./dist"));
 })
 
 gulp.task('build:css', () => {
@@ -80,7 +86,7 @@ gulp.task('dist:development', callback =>
 
 gulp.task('dist:production', callback => {
   process.env.NODE_ENV = 'production'
-  return runSequence('clean', 'copy:statics', 'build:css', 'clean:css', 'build:es6', 'uglify:js', callback)
+  return runSequence('clean', 'copy:statics', 'build:config', 'build:css', 'clean:css', 'build:es6', 'uglify:js', callback)
 })
 
 gulp.task('watch', ['dist:development'], () => {
@@ -97,5 +103,17 @@ gulp.task('serve', () => {
       host: '0.0.0.0',
     }))
 })
+
+// http://www.tonylunt.com/gulp/transforming-json-config-files-with-gulp/
+function newFile(name, contents) {
+    //uses the node stream object
+    const readableStream = require('stream').Readable({ objectMode: true });
+    //reads in our contents string
+    readableStream._read = function () {
+        this.push(new gutil.File({ cwd: "", base: "", path: name, contents: new Buffer.from(contents) }));
+        this.push(null);
+    }
+    return readableStream;
+};
 
 gulp.task('default', ['watch', 'serve'])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,11 +31,13 @@ gulp.task('copy:statics', () => {
 
 gulp.task('build:config', () => {
     const enviroment = gutil.env.env
+    const apiUrl = gutil.env.apiUrl
     console.log(`Enviroment => ${enviroment}`)
+    if(apiUrl) console.log(`apiUrl => ${apiUrl}`)
     let config = require('./src/conf/baseConfig.json')
     if( enviroment === "dev"){
         const devConfig = require('./src/conf/devConfig.json')
-        config = Object.assign({}, config, devConfig)
+        config = Object.assign({}, config, devConfig, { apiUrl: apiUrl || devConfig.apiUrl })
     }
     
     return newFile("config.json", JSON.stringify(config))

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "gulp": "node ./node_modules/gulp/bin/gulp.js --env 'build'",
+    "gulp": "node ./node_modules/gulp/bin/gulp.js",
     "dev": "node ./node_modules/gulp/bin/gulp.js --env 'dev'"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "gulp": "node ./node_modules/gulp/bin/gulp.js"
+    "gulp": "node ./node_modules/gulp/bin/gulp.js --env 'build'",
+    "dev": "node ./node_modules/gulp/bin/gulp.js --env 'dev'"
   },
   "repository": {
     "type": "git",

--- a/src/conf/baseConfig.json
+++ b/src/conf/baseConfig.json
@@ -1,6 +1,7 @@
-var config = {
+{
   "apiUrl": "https://toguru.autoscout24.com",
   "slackLink": "slack://channel?id={CHANNEL_ID}&team={TEAM_ID}",
   "hashRouting": true,
-  "entriesPerPage": 20
-};
+  "entriesPerPage": 20,
+  "auth" : true
+}

--- a/src/conf/devConfig.json
+++ b/src/conf/devConfig.json
@@ -1,0 +1,4 @@
+{
+    "apiUrl": "http://localhost:9000",
+    "auth" : false
+  }

--- a/src/state/store.es6
+++ b/src/state/store.es6
@@ -1,8 +1,9 @@
 import {createStore, applyMiddleware, compose} from 'redux'
 import thunk from 'redux-thunk'
 import DevTools from '../components/devTools';
-
 import {arrayToObject} from './../utils.es6'
+
+import config from '../../dist/config.json'
 
 const SET_TOGGLES = 'SET_TOGGLES'
 const SET_TOGGLE = 'SET_TOGGLE'
@@ -16,7 +17,7 @@ const DISABLE_TOGGLE = 'DISABLE_TOGGLE'
 const API_KEY = 'API_KEY'
 
 const defaultState = {
-    config: config,
+    config,
     toggles: {},
     auditLog: [],
     apiKey: localStorage.getItem(API_KEY),

--- a/static/index.html
+++ b/static/index.html
@@ -15,6 +15,5 @@
    <body>
       <div id="content"></div>
    </body>
-   <script src="./config.json" type="text/javascript"></script>
    <script src="./app.js" type="text/javascript"></script>
 </html>


### PR DESCRIPTION
The scope of the PR is to make tweaking the configuration files easier.
Going to the codebase it took me a while to understand why `config.json` was called that way when it was actually a js file and changing the value of a configuration variable was quite hacky.

The PR introduces a `conf` folder for the config files. Right now only the `baseConfig` and the `devConfig` are present.
The `build:config` task has been changed to output a `config.json` file in the `dist` folder that is then imported in the default state.
When running in `dev` mode every settings present in the `devConfig` will override what is present in the base one.