### PR TITLE
Allow description and tags update as well

### DIFF
--- a/src/router.es6
+++ b/src/router.es6
@@ -31,7 +31,7 @@ const RouteSwitch = () => (
   <Switch>
     <Route exact path="/" component={TogglesPage}/>
     <Route path="/edit/:toggleId" component={ToggleEditPage}/>
-    <Route path="/create" component={ToggleEditPage}/>
+    <Route path="/create" render={(props) => <ToggleEditPage {...props} isNewToggle={true} />}/>
     <Route path="/history" component={AuditLogPage}/>
     <Route path="*" component={TogglesPage}/>
   </Switch>

--- a/src/toggleEditPage.es6
+++ b/src/toggleEditPage.es6
@@ -44,7 +44,6 @@ class ToggleEdit extends React.Component {
     }
 
     fillState(toggle) {
-        console.log(toggle)
         if(toggle) {
             this.setState({
                 id: toggle.id,
@@ -107,7 +106,6 @@ class ToggleEdit extends React.Component {
                 this.props.dispatch(updateToggle(toggle))
                     .then(_ => this.setState({saved: true}))
                     .catch(e => {
-                        console.log(e)
                         switch(e.type){
                             case "ACTIVATION_ATTRIBUTES": {
                                 this.setState({ 

--- a/src/togglesPage.es6
+++ b/src/togglesPage.es6
@@ -80,9 +80,7 @@ export const TogglesPage =
         }
       },
       componentDidMount() {
-        if (this.props.toggles.length == 0) {
-          this.fetchList()
-        }
+        this.fetchList()
       },
       fetchList() {
         this.setState({ fetchStatus: "loading" })


### PR DESCRIPTION
Right now to edit the description of the tag of a toggle it needs to be deleted and created again.
The scope of the PR is to allow editing the description and tag while editing.

Forces toggle refresh when in toggle list.